### PR TITLE
Fix Unregistered scoreboard component error

### DIFF
--- a/src/main/java/me/matsubara/roulette/RoulettePlugin.java
+++ b/src/main/java/me/matsubara/roulette/RoulettePlugin.java
@@ -98,10 +98,10 @@ public final class RoulettePlugin extends JavaPlugin {
         if (hasDependency("Essentials")) essXExtension = new EssXExtension(this);
 
         // Team used to disable the nametag of NPCs.
-        hideTeam = createTeam("rouletteHide", Team.Option.NAME_TAG_VISIBILITY);
+        getHideTeam();
 
         // Team used to disable collisions for players inside the game (sitting on chair).
-        collisionTeam = createTeam("rouletteCollide", Team.Option.COLLISION_RULE);
+        getCollisionTeam();
 
         // Initialize managers.
         chipManager = new ChipManager(this);
@@ -225,10 +225,16 @@ public final class RoulettePlugin extends JavaPlugin {
     }
 
     public Team getHideTeam() {
+        if(hideTeam == null || Bukkit.getScoreboardManager().getMainScoreboard().getTeam("rouletteHide") == null){
+            hideTeam = createTeam("rouletteHide", Team.Option.NAME_TAG_VISIBILITY);
+        }
         return hideTeam;
     }
 
     public Team getCollisionTeam() {
+        if(collisionTeam == null || Bukkit.getScoreboardManager().getMainScoreboard().getTeam("rouletteCollide") == null){
+            collisionTeam = createTeam("rouletteCollide", Team.Option.COLLISION_RULE);
+        }
         return collisionTeam;
     }
 }

--- a/src/main/java/me/matsubara/roulette/game/Game.java
+++ b/src/main/java/me/matsubara/roulette/game/Game.java
@@ -201,7 +201,7 @@ public final class Game {
             plugin.getNPCPool().removeNPC(npc.getEntityId());
         }
 
-        if (name == null) name = "";
+        if (name == null) name = ConfigManager.Config.UNNAMED_CROUPIER.asString();
 
         // Hide npc name if empty string.
         if (name.trim().isEmpty()) {

--- a/src/main/java/me/matsubara/roulette/manager/InputManager.java
+++ b/src/main/java/me/matsubara/roulette/manager/InputManager.java
@@ -38,7 +38,7 @@ public final class InputManager implements Listener {
         this.players = new HashMap<>();
     }
 
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onAsyncPlayerChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
         if (!player.hasMetadata("rouletteEditing")) return;

--- a/src/main/java/me/matsubara/roulette/manager/InputManager.java
+++ b/src/main/java/me/matsubara/roulette/manager/InputManager.java
@@ -38,7 +38,7 @@ public final class InputManager implements Listener {
         this.players = new HashMap<>();
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onAsyncPlayerChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
         if (!player.hasMetadata("rouletteEditing")) return;


### PR DESCRIPTION
There is an error when you create a roulette table, the issue happens with some plugin manipulating scoreboards, a compatibility problem.

Is due because can't register an empty component, so in this case for avoid empty name for the NPC, will get the unnamed name croupier from config.

`Caused by: java.lang.IllegalStateException: Unregistered scoreboard component
        at org.bukkit.craftbukkit.v1_19_R1.scoreboard.CraftTeam.checkState(CraftTeam.java:403) ~[paper-1.19.2.jar:git-Paper-131]
        at org.bukkit.craftbukkit.v1_19_R1.scoreboard.CraftTeam.addEntry(CraftTeam.java:232) ~[paper-1.19.2.jar:git-Paper-131]
        at me.matsubara.roulette.game.Game.setNPC(Game.java:208) ~[Roulette-1.9.1-SNAPSHOT.jar:?]
        at me.matsubara.roulette.game.Game.<init>(Game.java:140) ~[Roulette-1.9.1-SNAPSHOT.jar:?]
        at me.matsubara.roulette.manager.GameManager.add(GameManager.java:81) ~[Roulette-1.9.1-SNAPSHOT.jar:?]
        at me.matsubara.roulette.manager.GameManager.add(GameManager.java:53) ~[Roulette-1.9.1-SNAPSHOT.jar:?]
        at me.matsubara.roulette.command.Main.onCommand(Main.java:144) ~[Roulette-1.9.1-SNAPSHOT.jar:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        ... 23 more`

This fix has been tested.